### PR TITLE
fix: Ignore various defaults

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,6 +5,10 @@ require:
 AllCops:
   NewCops: enable
   Exclude:
+    - node_modules/**/*
+    - tmp/**/*
+    - vendor/**/*
+    - .git/**/*
     - db/**/*
     - bin/**/*
 Style:


### PR DESCRIPTION
This came about from a big in GHA: https://github.com/rubocop/rubocop/issues/9832

Since we're overriding the default, we were no longer excluding defaults. I've added them back in here.