### PR TITLE
fix: anonymous blocks break rubyfmt

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -20,3 +20,8 @@ Metrics/BlockLength:
     - spec/**/*_spec.rb
 Metrics/ClassLength:
   Enabled: false
+
+# Disabled because rubyfmt breaks on this syntax.
+# To re-enable when fixed.
+Naming/BlockForwarding:
+  Enabled: false


### PR DESCRIPTION
The Rubyfmt people are currently working on supporting newer syntax, but some still breaks the tool, and this is one of them. See:

- https://rubyreferences.github.io/rubychanges/3.1.html#anonymous-block-argument
- https://github.com/fables-tales/rubyfmt/issues/399