### PR TITLE
fix: Migrate to plugin

### DIFF
--- a/rails.yml
+++ b/rails.yml
@@ -1,7 +1,7 @@
 inherit_from:
   https://raw.github.com/nedap/rubocop-config/main/rubocop.yml
 
-require:
+plugins:
   - rubocop-rails
 
 # This rule was historically misguided in believing that slashes

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:


### PR DESCRIPTION
- update the RuboCop extension cops specified in configuration files  from require to plugins.
 

> [The plugin system was introduced in RuboCop 1.72.](https://docs.rubocop.org/rubocop/plugin_migration_guide.html)